### PR TITLE
Contentful用のプラグイン・設定ファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ sw.*
 
 # Vim swap files
 *.swp
+
+# .contentful.json
+.contentful.json

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,4 @@
-const configContentful = require('./.contentful.json')
+import configContentful from './.contentful.json'
 
 export default {
   // Target: https://go.nuxtjs.dev/config-target
@@ -6,7 +6,7 @@ export default {
 
   env: {
     CONTENTFUL_SPACE_ID: configContentful.CONTENTFUL_SPACE_ID,
-    CONTENTFUL_CDA_ACCESS_TOKEN: configContentful.CONTENTFUL_CDA_ACCESS_TOKEN
+    CONTENTFUL_CDA_ACCESS_TOKEN: configContentful.CONTENTFUL_CDA_ACCESS_TOKEN,
   },
 
   // Global page headers: https://go.nuxtjs.dev/config-head

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,13 @@
+const config_contentful = require('./.contentful.json')
+
 export default {
   // Target: https://go.nuxtjs.dev/config-target
   target: 'static',
+
+  env: {
+    CONTENTFUL_SPACE_ID: config_contentful.CONTENTFUL_SPACE_ID,
+    CONTENTFUL_CDA_ACCESS_TOKEN: config_contentful.CONTENTFUL_CDA_ACCESS_TOKEN
+  },
 
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,12 +1,12 @@
-const config_contentful = require('./.contentful.json')
+const configContentful = require('./.contentful.json')
 
 export default {
   // Target: https://go.nuxtjs.dev/config-target
   target: 'static',
 
   env: {
-    CONTENTFUL_SPACE_ID: config_contentful.CONTENTFUL_SPACE_ID,
-    CONTENTFUL_CDA_ACCESS_TOKEN: config_contentful.CONTENTFUL_CDA_ACCESS_TOKEN
+    CONTENTFUL_SPACE_ID: configContentful.CONTENTFUL_SPACE_ID,
+    CONTENTFUL_CDA_ACCESS_TOKEN: configContentful.CONTENTFUL_CDA_ACCESS_TOKEN
   },
 
   // Global page headers: https://go.nuxtjs.dev/config-head

--- a/plugins/contentful.js
+++ b/plugins/contentful.js
@@ -1,0 +1,10 @@
+const contentful = require('contentful')
+const config = {
+  space: process.env.CONTENTFUL_SPACE_ID,
+  accessToken: process.env.CONTENTFUL_CDA_ACCESS_TOKEN,
+}
+module.exports = {
+  createClient() {
+    return contentful.createClient(config)
+  },
+}


### PR DESCRIPTION
## Context
- Headless CMSを利用する方針で、今回はContentfulを採択

## Problem
- Contentful関連のNuxt.js向けのプラグインが未導入

## Solution
- ``yarn add contentful``
- 設定ファイル類を追加・追記
  - ``./plugins/contentful.js``
- 環境変数事故防止のために導入段階でgitignoreに以下を追記``.contentful.json``